### PR TITLE
Indentation and documentation fixes. Restore error reporting level after request.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 
 # COMPOSER
 /vendor
+composer.lock
 
 # BUILD FILES
 /node_modules/*
@@ -16,3 +17,6 @@
 .DS_Store
 .DQ
 .php_cs.cache
+
+# IDE / editor
+.idea/

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Simple Json client plugin for Craft3 CMS. The plugin provides a simple Twig exte
 ## Installing using composer
 1. Go to the project craft folder in the terminal and run
 
-       composer require dolphiq/craft3-jsonclient
+       composer require dolphiq/jsonclient
 
 2. Install plugin in the Craft Control Panel under Settings > Plugins
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Simple Json client plugin for Craft3 CMS. The plugin provides a simple Twig exte
 This is a forked version from https://github.com/Dolphiq/craft3-jsonclient/
 
 It was forked to fix some issues, mostly regarding error handling and
-code standards.
+coding standards.
 
 ## Requirements
 * Craft 3.0 (RC14)+
@@ -13,16 +13,20 @@ code standards.
 
 ## Using the plugin
 1. Install it using composer or the plugin store.
-2. You can use it from your template
+2. Do composer.json updates - see "Installing using composer"
+3. You can use it from your template
 
 ### Using the plugin in your twig template
         {# Get a random Fact form chucknorris.io #}
         {% set jsonData = fetchJson({
-        'url': 'https://api.chucknorris.io/jokes/random'
+          'url': 'https://api.chucknorris.io/jokes/random'
         }) %}
 
-        <h1>Fact of the day</h1>
-        {{ jsonData.value }}
+        {% if (jsonData) %}
+          <h1>Fact of the day</h1>
+          {{ jsonData.value }}
+        {% endif %}
+
 
 ## Installing using composer
 1. Go to the project craft folder in the terminal and run

--- a/README.md
+++ b/README.md
@@ -2,8 +2,13 @@
 
 Simple Json client plugin for Craft3 CMS. The plugin provides a simple Twig extension which allows you to fetch a Json url and use the result in your Twig template.
 
+This is a forked version from https://github.com/Dolphiq/craft3-jsonclient/
+
+It was forked to fix some issues, mostly regarding error handling and
+code standards.
+
 ## Requirements
-* Craft 3.0 (beta 20)+
+* Craft 3.0 (RC14)+
 * PHP 7.0+
 
 ## Using the plugin
@@ -24,7 +29,22 @@ Simple Json client plugin for Craft3 CMS. The plugin provides a simple Twig exte
 
        composer require dolphiq/jsonclient
 
-2. Install plugin in the Craft Control Panel under Settings > Plugins
+2. Add forked version to composer.json
+
+       {
+           "repositories": [
+               {
+                   "type": "vcs",
+                   "url": "https://github.com/kbergha/jsonclient"
+               }
+           ],
+           "require": {
+               "dolphiq/jsonclient": "dev-development"
+           }
+       }
+
+3. Run composer update to get forked/fixed version
+4. Install plugin in the Craft Control Panel under Settings > Plugins
 
 ## Roadmap
 - Create filters for xss scripts

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ code standards.
            "repositories": [
                {
                    "type": "vcs",
-                   "url": "https://github.com/kbergha/jsonclient"
+                   "url": "https://github.com/kbergha/craft3-jsonclient"
                }
            ],
            "require": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "~3.0.0-beta.1"
+        "craftcms/cms": "^3.0.0-RC14"
     },
     "autoload": {
         "psr-4": {

--- a/src/JsonClientPlugin.php
+++ b/src/JsonClientPlugin.php
@@ -14,29 +14,15 @@ use Craft;
 use craft\base\Plugin;
 use dolphiq\jsonclient\twigextensions\JsonClientTwigExtension;
 
-
-// use dolphiq\jsonclient\controllers\jsonclientController;
-
-
-use craft\base\Object;
-
-class JsonClientPlugin extends \craft\base\Plugin
+class JsonClientPlugin extends Plugin
 {
     public static $plugin;
-
-    public $hasCpSettings = false;
-
-    // table schema version
-    public $schemaVersion = '1.0.0';
 
     public function init()
     {
         parent::init();
-
         self::$plugin = $this;
-
         Craft::$app->view->twig->addExtension(new JsonClientTwigExtension());
-
         Craft::info('dolphiq/jsonclient plugin loaded', __METHOD__);
     }
 }

--- a/src/twigextensions/JsonClientTwigExtension.php
+++ b/src/twigextensions/JsonClientTwigExtension.php
@@ -4,6 +4,7 @@ namespace dolphiq\jsonclient\twigextensions;
 
 use Twig_Extension;
 use Twig_SimpleFunction;
+use Craft;
 
 class JsonClientTwigExtension extends Twig_Extension
 {
@@ -30,17 +31,18 @@ class JsonClientTwigExtension extends Twig_Extension
     /**
      * Returns JSON from URL.
      *
-     * @param array $options Options, just URL for now.
+     * @param array $parameters Parameters, just URL for now.
      *
      * @return string
      */
-    public function fetchJson($options = [])
+    public function fetchJson($parameters = [])
     {
-        if (!isset($options['url'])) {
-            die('Required url parameter not set!');
+        if (!isset($parameters['url'])) {
+            Craft::error('URL parameter not set', __METHOD__);
+            return false;
         }
 
-        $data = self::getUrl($options['url']);
+        $data = self::getUrl($parameters['url']);
         return json_decode($data, true);
     }
 

--- a/src/twigextensions/JsonClientTwigExtension.php
+++ b/src/twigextensions/JsonClientTwigExtension.php
@@ -41,11 +41,8 @@ class JsonClientTwigExtension extends Twig_Extension
      */
     public function fetchJson($options = [])
     {
-        //return \view::render('settings', []);
-        // return 'twitter feed...';
-
         if (!isset($options['url'])) {
-          die('Required url parameter not set!');
+            die('Required url parameter not set!');
         }
 
         $data = self::getUrl($options['url']);
@@ -54,19 +51,17 @@ class JsonClientTwigExtension extends Twig_Extension
 
     }
 
-		// Function for cURL
-		private static function getUrl($url) {
-			error_reporting(0);
+    // Function for cURL
+    private static function getUrl($url) {
+        error_reporting(0);
 
-			$ch = curl_init();
-			curl_setopt($ch, CURLOPT_URL, $url);
-			curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-			$store = curl_exec($ch);
-			curl_close($ch);
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        $store = curl_exec($ch);
+        curl_close($ch);
 
-			return $store;
-		}
-
-
+        return $store;
+    }
 
 }

--- a/src/twigextensions/JsonClientTwigExtension.php
+++ b/src/twigextensions/JsonClientTwigExtension.php
@@ -34,9 +34,10 @@ class JsonClientTwigExtension extends Twig_Extension
     }
 
     /**
-     * Returns versioned file or the entire tag.
+     * Returns JSON from URL.
      *
-     * @param  string  $file
+     * @param array $options Options, just URL for now.
+     *
      * @return string
      */
     public function fetchJson($options = [])
@@ -51,15 +52,24 @@ class JsonClientTwigExtension extends Twig_Extension
 
     }
 
-    // Function for cURL
-    private static function getUrl($url) {
-        error_reporting(0);
+    /**
+     * Function for actually getting data with cURL
+     *
+     * @param string $url URL to fetch
+     *
+     * @return mixed
+     */
+    private static function getUrl($url)
+    {
+        $oldErrorLevel = error_reporting(0);
 
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         $store = curl_exec($ch);
         curl_close($ch);
+
+        error_reporting($oldErrorLevel);
 
         return $store;
     }

--- a/src/twigextensions/JsonClientTwigExtension.php
+++ b/src/twigextensions/JsonClientTwigExtension.php
@@ -2,14 +2,8 @@
 
 namespace dolphiq\jsonclient\twigextensions;
 
-use dolphiq\jsonclient\jsonclient;
-
 use Twig_Extension;
-use Twig_SimpleFilter;
 use Twig_SimpleFunction;
-
-use Craft;
-use ReflectionProperty;
 
 class JsonClientTwigExtension extends Twig_Extension
 {
@@ -29,7 +23,7 @@ class JsonClientTwigExtension extends Twig_Extension
     public function getFunctions()
     {
         return [
-            new Twig_SimpleFunction('fetchJson', [$this, 'fetchJson']),
+            new Twig_SimpleFunction('fetchJson', [$this, 'fetchJson'])
         ];
     }
 
@@ -47,9 +41,7 @@ class JsonClientTwigExtension extends Twig_Extension
         }
 
         $data = self::getUrl($options['url']);
-
         return json_decode($data, true);
-
     }
 
     /**
@@ -59,7 +51,7 @@ class JsonClientTwigExtension extends Twig_Extension
      *
      * @return mixed
      */
-    private static function getUrl($url)
+    protected static function getUrl($url)
     {
         $oldErrorLevel = error_reporting(0);
 
@@ -73,5 +65,4 @@ class JsonClientTwigExtension extends Twig_Extension
 
         return $store;
     }
-
 }


### PR DESCRIPTION
Hi. 

I've cleaned up some code indentation, and fixed some wrong/missing documentation.
I've also added restoring the previous error reporting level after the request is finished.