### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/JsonClientPlugin.php
+++ b/src/JsonClientPlugin.php
@@ -35,7 +35,7 @@ class JsonClientPlugin extends \craft\base\Plugin
 
         self::$plugin = $this;
 
-        Craft::$app->view->twig->addExtension(new JsonClientTwigExtension());
+        Craft::$app->view->registerTwigExtension(new JsonClientTwigExtension());
 
         Craft::info('dolphiq/jsonclient plugin loaded', __METHOD__);
     }


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.