### PR TITLE
Remove unused reference to non-existent class

### DIFF
--- a/src/JsonClientPlugin.php
+++ b/src/JsonClientPlugin.php
@@ -14,12 +14,6 @@ use Craft;
 use craft\base\Plugin;
 use dolphiq\jsonclient\twigextensions\JsonClientTwigExtension;
 
-
-// use dolphiq\jsonclient\controllers\jsonclientController;
-
-
-use craft\base\Object;
-
 class JsonClientPlugin extends \craft\base\Plugin
 {
     public static $plugin;


### PR DESCRIPTION
A warning is thrown in PHP 7.2 that `Object` is a reserved word that should not be used for class names. In addition, this class is never referenced in any way within the plugin, and should therefore be removed. This is in reference to issue #5 