### PR TITLE
Update composer.json Craft requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "~3.0.0-beta.1"
+        "craftcms/cms": "^3.0.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
With the release of Craft 3.1, the requirement definition here is no longer met. This update should allow the update to Craft 3.1 without throwing an error like this:

```
- dolphiq/jsonclient 1.0.2 requires craftcms/cms ~3.0.0-beta.1 -> satisfiable by craftcms/cms[3.0.0, 3.0.0-RC1, 3.0.0-RC10, 3.0.0-RC10.1, 3.0.0-RC11, 3.0.0-RC12, 3.0.0-RC13, 3.0.0-RC14, 3.0.0-RC15, 3.0.0-RC16, 3.0.0-RC16.1, 3.0.0-RC17, 3.0.0-RC17.1, 3.0.0-RC2, 3.0.0-RC3, 3.0.0-RC4, 3.0.0-RC5, 3.0.0-RC6, 3.0.0-RC7, 3.0.0-RC7.1, 3.0.0-RC8, 3.0.0-RC9, 3.0.0-beta.1, 3.0.0-beta.10, 3.0.0-beta.11, 3.0.0-beta.12, 3.0.0-beta.13, 3.0.0-beta.14, 3.0.0-beta.15, 3.0.0-beta.16, 3.0.0-beta.17, 3.0.0-beta.18, 3.0.0-beta.19, 3.0.0-beta.2, 3.0.0-beta.20, 3.0.0-beta.21, 3.0.0-beta.22, 3.0.0-beta.23, 3.0.0-beta.24, 3.0.0-beta.25, 3.0.0-beta.26, 3.0.0-beta.27, 3.0.0-beta.28, 3.0.0-beta.29, 3.0.0-beta.3, 3.0.0-beta.30, 3.0.0-beta.31, 3.0.0-beta.32, 3.0.0-beta.33, 3.0.0-beta.34, 3.0.0-beta.35, 3.0.0-beta.36, 3.0.0-beta.4, 3.0.0-beta.5, 3.0.0-beta.6, 3.0.0-beta.7, 3.0.0-beta.8, 3.0.0-beta.9, 3.0.0.1, 3.0.0.2, 3.0.1, 3.0.10, 3.0.10.1, 3.0.10.2, 3.0.10.3, 3.0.11, 3.0.12, 3.0.13, 3.0.13.1, 3.0.13.2, 3.0.14, 3.0.15, 3.0.16, 3.0.16.1, 3.0.17, 3.0.17.1, 3.0.18, 3.0.19, 3.0.2, 3.0.20, 3.0.21, 3.0.22, 3.0.23, 3.0.23.1, 3.0.24, 3.0.25, 3.0.26, 3.0.26.1, 3.0.27, 3.0.27.1, 3.0.28, 3.0.29, 3.0.3, 3.0.3.1, 3.0.30, 3.0.30.1, 3.0.30.2, 3.0.31, 3.0.32, 3.0.33, 3.0.34, 3.0.35, 3.0.36, 3.0.37, 3.0.4, 3.0.5, 3.0.6, 3.0.7, 3.0.8, 3.0.9] but these conflict with your requirements or minimum-stability.
```